### PR TITLE
Pass params to parallel

### DIFF
--- a/BeRCM/model/parallel.py
+++ b/BeRCM/model/parallel.py
@@ -17,15 +17,13 @@ def main(n_processes, param_path):
     # From https://stackoverflow.com/questions/19156467/
     procs = []
     print(f'Running {n_processes} processes of BeRCM in parallel...')
-    proc_ids = []
     for i in range(n_processes):
         if sys.platform.startswith('win32'):
             proc = subprocess.Popen([sys.executable, 'run.py', param_path[i]], creationflags=subprocess.CREATE_NEW_CONSOLE)
         else:
             proc = subprocess.Popen([sys.executable, 'run.py', param_path[i]])
         procs.append(proc)
-        proc_ids.append(proc.pid)
-    print(f'Process ID list: {proc_ids}')
+        print(f'Process [{proc.pid}] using {param_path[i]}')
 
     # TODO: add communication/timeout errors with process
     # TODO: add stream for sterror
@@ -39,7 +37,7 @@ def parse_arguments():
     parser.add_argument("pcount", help="Number of processes to run")
     parser.add_argument("param", default='param.yaml', nargs='*', help="Test variable")
     args = parser.parse_args()
-    return args.pcount, args.param
+    return int(args.pcount), args.param
 
 if __name__ == '__main__':
     n_processes, param_path = parse_arguments()

--- a/BeRCM/model/parallel.py
+++ b/BeRCM/model/parallel.py
@@ -1,17 +1,49 @@
 import sys
 import subprocess
+import argparse
 
-n_processes = 2
-# Using https://stackoverflow.com/questions/19156467/
-procs = []
-print(f'Running {n_processes} processes of BeRCM in parallel...')
-for i in range(n_processes):
-    if sys.platform.startswith('win32'):
-        proc = subprocess.Popen([sys.executable, 'run.py'], creationflags=subprocess.CREATE_NEW_CONSOLE)
-    else:
-        proc = subprocess.Popen([sys.executable, 'run.py'])
-    procs.append(proc)
+def main(n_processes, param_path):
+    if n_processes != len(param_path) and len(param_path) != 1:
+        print(
+            f'Required {n_processes} or 1 parameter file(s) but {len(param_path)} '
+            f'provided...'
+        )
+        return 
+    # If just one paramter file passed, all processes will use it
+    if len(param_path) == 1:
+        for _ in range(n_processes-1):
+            param_path.append(param_path[0])
 
-for proc in procs:
-    proc.wait()
+    # From https://stackoverflow.com/questions/19156467/
+    procs = []
+    print(f'Running {n_processes} processes of BeRCM in parallel...')
+    proc_ids = []
+    for i in range(n_processes):
+        if sys.platform.startswith('win32'):
+            proc = subprocess.Popen([sys.executable, 'run.py', param_path[i]], creationflags=subprocess.CREATE_NEW_CONSOLE)
+        else:
+            proc = subprocess.Popen([sys.executable, 'run.py', param_path[i]])
+        procs.append(proc)
+        proc_ids.append(proc.pid)
+    print(f'Process ID list: {proc_ids}')
+
+    # TODO: add communication/timeout errors with process
+    # TODO: add stream for sterror
+    for proc in procs:
+        proc.wait()
+    print(f'All processes complete.')
+    return 
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='A test')
+    parser.add_argument("pcount", help="Number of processes to run")
+    parser.add_argument("param", default='param.yaml', nargs='*', help="Test variable")
+    args = parser.parse_args()
+    return args.pcount, args.param
+
+if __name__ == '__main__':
+    n_processes, param_path = parse_arguments()
+    main(n_processes, param_path)
+
+
 

--- a/BeRCM/model/run.py
+++ b/BeRCM/model/run.py
@@ -175,10 +175,8 @@ def main(run_id, pid):
 if __name__ == '__main__':
 
     pid = os.getpid()
-    print(f'Process [{pid}] running 1 instance of BeRCM...')
     run_id = datetime.now().strftime('%Y%m-%d%H-%M%S-') + str(uuid4())
-    print(f'[{pid}] Using UUID: {run_id}')
-    # TODO: make sure UUID/filename has not already been used
+    print(f'Process [{pid}] using UUID: {run_id}')
     main(run_id, pid)
 
     


### PR DESCRIPTION
Allow a user to set the number of processes to spawn and the related parameter file paths through command arguments. 

User must give pcount (Number of processes to run). Parameter file paths will default to 'param.yaml' if no argument is given. If only one parameter file path is given then it will be used for all n processes. If k parameter file paths are given then k must equal n, where n is the number of processes.